### PR TITLE
DDT-2219 - PHP 8 Upgrade - GRPC Datastore amend

### DIFF
--- a/src/GDS/Gateway/GRPCv1.php
+++ b/src/GDS/Gateway/GRPCv1.php
@@ -29,7 +29,7 @@ use Google\Cloud\Datastore\V1\Entity as GRPC_Entity;
 use Google\Cloud\Datastore\V1\Key;
 use Google\Cloud\Datastore\V1\Key\PathElement as KeyPathElement;
 use Google\Cloud\Datastore\V1\PartitionId;
-use Google\Cloud\Datastore\V1\CommitRequest_Mode;
+use Google\Cloud\Datastore\V1\CommitRequest\Mode as CommitRequest_Mode;
 use Google\Cloud\Datastore\V1\Mutation;
 use Google\Cloud\Datastore\V1\ReadOptions;
 use Google\Cloud\Datastore\V1\GqlQuery;


### PR DESCRIPTION
 * Switch from deprecated class to alternative.

----

**Context:** 

In a project that uses this package, the php version was updated from 7.4 to 8.1

Doing so, meant that the deprecation error raised in the google cloud package was handled differently - previously it was suppressed.

https://github.com/googleapis/google-cloud-php-datastore/blob/main/src/V1/CommitRequest_Mode.php

https://php.watch/versions/8.0/fatal-error-suppression

The change here is to switch to the correct Mode class, as suggested by the error message.

**Tests**

There is a failing unit test, but it does not appear to be related to this amend

![Screenshot 2023-07-24 112522](https://github.com/a1comms/php-gds/assets/20857652/d8f85e72-720c-43b4-adfa-851497c90bcf)


**Notes**
 * I have retained the current required PHP version in composer.json
 * I have not updated the README

